### PR TITLE
Support for decimal point

### DIFF
--- a/src/TM1637.cpp
+++ b/src/TM1637.cpp
@@ -107,7 +107,8 @@ void TM1637::display(uint8_t value[4]) const
     mI2C.beginTransmission();
     mI2C.send(static_cast<uint8_t>(AddressCommand_e::C0H));
     for (uint8_t i = 0; i < TOTAL_DIGITS; i++)
-        colon ? mI2C.send(fetch(value[i]) + 0x80) : mI2C.send(fetch(value[i]));
+        // If colon is true, or bit i of dp is set, then turn on MSb
+        (colon || (dp & (1<<i))) ? mI2C.send(fetch(value[i]) + 0x80) : mI2C.send(fetch(value[i]));
     mI2C.endTransmission();
     mI2C.beginTransmission();
     mI2C.send(static_cast<uint8_t>(brightness));
@@ -181,4 +182,9 @@ void TM1637::setBrightness(uint8_t value) noexcept
 void TM1637::switchColon() noexcept
 {
     colon = !colon;
+}
+
+void TM1637::setDp(uint8_t value) noexcept
+{
+    dp = value;
 }

--- a/src/TM1637.h
+++ b/src/TM1637.h
@@ -68,6 +68,7 @@ protected:
     MI2C mI2C;
     DisplayControl_e brightness = DisplayControl_e::PULSE_WIDTH_4_16;
     bool colon = false;
+    uint8_t dp = 0x00; // dp LED bit pattern. LSb is leftmost dp.
     uint8_t numbers[10] = {0x3f, 0x06, 0x5B, 0x4F, 0x66, 0x6D, 0x7D, 0x07, 0x7F, 0x6F};
     uint8_t alphabet[6] = {0x77, 0x7C, 0x39, 0x5E, 0x79, 0x71};
     uint8_t minus       = 0x40;
@@ -84,6 +85,7 @@ public:
     void setBrightness(uint8_t value);
     void changeBrightness(uint8_t value) const;
     void switchColon() noexcept;
+    void setDp(uint8_t value);
     void offMode();
     void onMode();
     template <typename T>


### PR DESCRIPTION
Hi there,

There are two popular variants of LED modules based on TM1637. One is for clocks, and has two LEDs in the centre to act as a colon. The other has a decimal point (dp) LED in the conventional location of each digit position.

The proposed pull request adds an internal variable called 'dp' and a function 'setDp(n)' which creates a bitmap for which dp LEDs will be lit. On my 4-digit module the dps are wired from left to right, so setDp(0x01) will light the leftmost LED, and setDp(0x08) will light the rightmost LED. It is possible to light more than one dp if required (e.g. setDp(0x0F) will light all four dps).

The dp value overrides values sent by dispNumber() and display(). If you want to explicitly control all 8 LEDs in a digit then call setDp(0) before display().

If you don't like this implementation, but you like the idea, then please do provide some alternative method to control decimal point LEDs where present on these modules.

Thanks.

Andrew