### PR TITLE
Fix compilier error for ESP

### DIFF
--- a/src/animator.h
+++ b/src/animator.h
@@ -149,7 +149,7 @@ public:
                 sendToDisplay<DataCommand_e::AUTOMATIC_ADDRESS_ADDING, AddressCommand_e::C0H>(
                         brightness_,
                         reinterpret_cast<const uint8_t*>(s.c_str()),
-                        static_cast<size_t>(min(totalDigits_, s.length())));
+                        static_cast<size_t>(min((unsigned int)totalDigits_, s.length())));
             }
             return;
         }
@@ -192,7 +192,7 @@ public:
         sendToDisplay<DataCommand_e::AUTOMATIC_ADDRESS_ADDING, AddressCommand_e::C0H>(
                 brightness_,
                 reinterpret_cast<const uint8_t*>(buffer_.c_str()),
-                static_cast<size_t>(min(totalDigits_, buffer_.length())));
+                static_cast<size_t>(min((unsigned int)totalDigits_, buffer_.length())));
     }
 
 private:


### PR DESCRIPTION
Hello. 
My edits fix the compilation error for ESP8266 and ESP32. The problem seems to be related to the specifics of the implementation of the min()  in the core from Esspressif.

Thanks for Your work. Kostyantyn.